### PR TITLE
fix search and search pagination

### DIFF
--- a/fbone/frontend/views.py
+++ b/fbone/frontend/views.py
@@ -80,7 +80,7 @@ def search():
     pagination = None
     if keywords:
         page = int(request.args.get('page', 1))
-        pagination = User.search(keywords).paginate(page, 1)
+        pagination = User.search(keywords).paginate(page, 20)
     else:
         flash(_('Please input keyword(s)'), 'error')
     return render_template('frontend/search.html', pagination=pagination, keywords=keywords)

--- a/fbone/templates/frontend/search.html
+++ b/fbone/templates/frontend/search.html
@@ -1,4 +1,4 @@
-{% from 'macros/_misc.html' import render_pagination, render_user_table %}
+{% from 'macros/_misc.html' import render_pagination_search, render_user_table %}
 
 {% extends 'layouts/base.html' %}
 
@@ -12,7 +12,7 @@
     {% if pagination and pagination.pages > 0 %}
         <p>{% trans total=pagination.total, keywords=keywords %}<strong>{{ total }}</strong> found for your search "<strong>{{ keywords }}</strong>".{% endtrans %}</p>
         {{ render_user_table(pagination.items, 'zebra-striped') }}
-        {{ render_pagination(pagination, 'frontend.search') }}
+        {{ render_pagination_search(pagination, 'frontend.search', keywords=keywords) }}
     {% else %}
         <p>{% trans keywords=keywords %}Sorry, Nothing found for your search "<strong>{{ keywords }}</strong>".{% endtrans %}</p>
     {% trans %}

--- a/fbone/templates/macros/_misc.html
+++ b/fbone/templates/macros/_misc.html
@@ -2,7 +2,6 @@
 <table class='{{ class }}'>
     <thead>
         <tr>
-            <td>#</td>
             <td>Username</td>
             <td>Email</td>
         </tr>
@@ -10,8 +9,7 @@
     <tbody>
         {% for user in users %}
         <tr>
-            <td>{{ loop.index }}</td>
-            <td><a href="{{ url_for('user.profile', name=user.name) }}">{{ user.name }}</a></td>
+            <td><a href="{{ url_for('user.profile', user_id=user.id) }}">{{ user.name }}</a></td>
             <td>{{ user.email }}</td>
         </tr>
         {% endfor %}
@@ -21,6 +19,7 @@
 
 {% macro render_pagination(pagination, endpoint) %}
     {% if pagination.pages > 1 %}
+        
         <div class='pagination'>
             <ul>
                 <li class="prev {% if not pagination.has_prev %}disabled{% endif %}"><a href="{{ url_for(endpoint, page=pagination.page-1) }}">&larr; Previous</a></li>
@@ -36,6 +35,30 @@
                     {% endif %}
                 {% endfor %}
                 <li class="next {% if not pagination.has_next %}disabled{% endif %}"><a href="{{ url_for(endpoint, page=pagination.page+1) }}">Next &rarr;</a></li>
+            </ul>
+        </div>
+    {% endif %}
+{% endmacro %}
+
+
+{% macro render_pagination_search(pagination, endpoint) %}
+    {% if pagination.pages > 1 %}
+        
+        <div class='pagination'>
+            <ul>
+                <li class="prev {% if not pagination.has_prev %}disabled{% endif %}"><a href="{{ url_for(endpoint, keywords=kwargs.keywords, page=pagination.page-1) }}">&larr; Previous</a></li>
+                {% for page in pagination.iter_pages() %}
+                    {% if page %}
+                        <li class='{% if page == pagination.page %}active{% endif %}'>
+                            <a href='{{ url_for(endpoint, keywords=kwargs.keywords, page=page) }}'>{{ page }}</a>
+                        </li>
+                    {% else %}
+                        <li>
+                            <a href='#'>...</a>
+                        </li>
+                    {% endif %}
+                {% endfor %}
+                <li class="next {% if not pagination.has_next %}disabled{% endif %}"><a href="{{ url_for(endpoint, keywords=kwargs.keywords ,page=pagination.page+1) }}">Next &rarr;</a></li>
             </ul>
         </div>
     {% endif %}


### PR DESCRIPTION
# Search fix:

CRITICAL: Replaced "name=user.name" with "user_id=user.id" in fbone/templates/macros/_ misc.html, macro "render_user_table"
# Pagination fix:
1. Users per page changed from 1 to 20.
2. Removed "#" Collumn in render_user_table.
3. Created macro to paginate search results (render_pagination_search).
   A lot of redundant code (render_pagination). This should be improved in the future.
