### PR TITLE
Add Python 3 compatibilities

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -2,6 +2,7 @@
 """
 Fabfile for managing a Python/Flask/Apache/MySQL project in MacOS/Ubuntu.
 """
+from __future__ import print_function
 
 import os
 
@@ -109,11 +110,11 @@ def syncdb():
     """Sync loacl db with remote db"""
 
     if not REMOTE_DB_USERNAME or not REMOTE_DB_PASSWORD or not REMOTE_DB_NAME:
-        print "Please setup remote db configs"
+        print("Please setup remote db configs")
         return
 
     if not LOCAL_DB_USERNAME or not LOCAL_DB_PASSWORD or not LOCAL_DB_NAME:
-        print "Please setup local db configs"
+        print("Please setup local db configs")
         return
 
     with cd("/tmp"):

--- a/fbone/__init__.py
+++ b/fbone/__init__.py
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
 
-from app import create_app
+from __future__ import absolute_import
+from .app import create_app

--- a/fbone/app.py
+++ b/fbone/app.py
@@ -1,13 +1,14 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import absolute_import
 from flask import Flask, render_template
 
-from config import DefaultConfig
-from user import User
+from .config import DefaultConfig
+from .user import User
 
-from extensions import db, login_manager
-from filters import format_date, pretty_date, nl2br
-from utils import INSTANCE_FOLDER_PATH
+from .extensions import db, login_manager
+from .filters import format_date, pretty_date, nl2br
+from .utils import INSTANCE_FOLDER_PATH
 
 
 # For import *
@@ -70,9 +71,9 @@ def configure_extensions(app):
 def configure_blueprints(app):
     """Configure blueprints in views."""
 
-    from user import user
-    from frontend import frontend
-    from api import api
+    from .user import user
+    from .frontend import frontend
+    from .api import api
 
     for bp in [user, frontend, api]:
         app.register_blueprint(bp)

--- a/fbone/config.py
+++ b/fbone/config.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import absolute_import
+from builtins import object
 import os
 
-from utils import make_dir, INSTANCE_FOLDER_PATH
+from .utils import make_dir, INSTANCE_FOLDER_PATH
 
 
 class BaseConfig(object):

--- a/fbone/filters.py
+++ b/fbone/filters.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import division
+from past.utils import old_div
 import re
 from datetime import datetime
 from jinja2 import Markup, escape
@@ -18,12 +20,12 @@ def pretty_date(value, default="just now"):
     diff = now - value
 
     periods = (
-        (diff.days / 365, 'year', 'years'),
-        (diff.days / 30, 'month', 'months'),
-        (diff.days / 7, 'week', 'weeks'),
+        (old_div(diff.days, 365), 'year', 'years'),
+        (old_div(diff.days, 30), 'month', 'months'),
+        (old_div(diff.days, 7), 'week', 'weeks'),
         (diff.days, 'day', 'days'),
-        (diff.seconds / 3600, 'hour', 'hours'),
-        (diff.seconds / 60, 'minute', 'minutes'),
+        (old_div(diff.seconds, 3600), 'hour', 'hours'),
+        (old_div(diff.seconds, 60), 'minute', 'minutes'),
         (diff.seconds, 'second', 'seconds'),
     )
 

--- a/fbone/frontend/__init__.py
+++ b/fbone/frontend/__init__.py
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
 
-from views import frontend
+from __future__ import absolute_import
+from .views import frontend

--- a/fbone/frontend/views.py
+++ b/fbone/frontend/views.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import absolute_import
+from builtins import str
 from uuid import uuid4
 
 from flask import Blueprint, render_template, current_app, request, flash, \
@@ -9,7 +11,7 @@ from flask_login import login_required, login_user, current_user, logout_user, \
 
 from fbone.user import User
 from fbone.extensions import db, login_manager
-from forms import SignupForm, LoginForm, RecoverPasswordForm, ReauthForm, \
+from .forms import SignupForm, LoginForm, RecoverPasswordForm, ReauthForm, \
     ChangePasswordForm
 
 

--- a/fbone/user/__init__.py
+++ b/fbone/user/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from models import User
-from views import user
+from __future__ import absolute_import
+from .models import User
+from .views import user

--- a/fbone/user/models.py
+++ b/fbone/user/models.py
@@ -11,6 +11,7 @@ from fbone.extensions import db
 from fbone.utils import get_current_time
 from fbone.constants import USER, USER_ROLE, ADMIN, INACTIVE, USER_STATUS, \
     SEX_TYPES, STRING_LEN
+from functools import reduce
 
 
 class User(db.Model, UserMixin):

--- a/fbone/user/views.py
+++ b/fbone/user/views.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import absolute_import
 import os
 
 from flask import Blueprint, render_template, send_from_directory, request, \
     current_app, flash
 from flask_login import login_required, current_user
 
-from forms import ProfileForm, PasswordForm
+from .forms import ProfileForm, PasswordForm
 
 from fbone.extensions import db
 from fbone.utils import get_current_time

--- a/fbone/utils.py
+++ b/fbone/utils.py
@@ -3,6 +3,7 @@
     Utils has nothing to do with models and views.
 """
 
+from builtins import range
 import string
 import random
 import os
@@ -35,5 +36,5 @@ def make_dir(dir_path):
     try:
         if not os.path.exists(dir_path):
             os.mkdir(dir_path)
-    except Exception, e:
+    except Exception as e:
         raise e

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-Fabric
+Fabric; python_version < '3.0'
+Fabric3; python_version >= '3.0'
 Flask
 Flask-Login
 Flask-RESTful
@@ -7,7 +8,8 @@ Flask-Testing
 Flask-WTF
 Jinja2
 MarkupSafe
-MySQL-python
+MySQL-python; python_version < '3.0'
+mysqlclient; python_version >= '3.0'
 SQLAlchemy
 WTForms
 Werkzeug
@@ -31,6 +33,10 @@ python-dateutil
 pytz
 requests
 six
-speaklater
+speaklater; python_version < '3.0'
+speaklater3; python_version >= '3.0'
 wrapt
-wsgiref
+wsgiref; python_version < '3.0'
+future
+six
+

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from past.builtins import execfile
 import sys, os, pwd
 
 project = "fbone"


### PR DESCRIPTION
- Use features from `future` and `six` to allow Python 2 and 3 code to
co-exist
- Use `futurize` to add compatibility to existing Python 2 code
- Use conditional imports in `requirements.txt`