### PR TITLE
update utils.py for py3 and backwards-compatible with py2

### DIFF
--- a/fbone/user/forms.py
+++ b/fbone/user/forms.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from flask_wtf import Form
-from flask_wtf.html5 import URLField, EmailField, TelField
+from wtforms.fields.html5 import URLField, EmailField, TelField
 
 from wtforms import ValidationError, StringField, PasswordField, SubmitField, \
     TextAreaField, FileField, DateField, SelectField

--- a/fbone/utils.py
+++ b/fbone/utils.py
@@ -35,5 +35,5 @@ def make_dir(dir_path):
     try:
         if not os.path.exists(dir_path):
             os.mkdir(dir_path)
-    except Exception, e:
+    except getopt.GetoptError as e: # in python3 the raise syntax no longer accepts comma-separated arguments
         raise e


### PR DESCRIPTION
fbone/fbone/utils.py", line 38
    except Exception, e:   
will trigger SyntaxError: invalid syntax since in python3 the raise syntax no longer accepts comma-separated arguments.

